### PR TITLE
meta: Define site description for search engines

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -66,7 +66,7 @@ function Home() {
   return (
     <Layout
       title={`qAIRa ${siteConfig.title}`}
-      description="Description will go into a meta tag in <head />">
+      description="Open Source documentation for qAIRa Drones. We act against the global problem of pollution by monitoring the quality of air continuously at anytime and anywhere.">
       <header className={clsx('hero hero--primary', styles.heroBanner)}>
         <div className="container">
           <h1 className="hero__title">{siteConfig.title}</h1>


### PR DESCRIPTION
This commit adds a description to the documentation website for search
engines and social media platforms. Now, when you share the link online,
this short string is returned as part of a URL preview in Microsoft
Outlook, Twitter, WhatsApp, etc.

It will also have a small impact on Search Engine Optimization (S.E.O.)
to make your docs more discoverable online.