### PR TITLE
ci: Fix paths for Circle CI environment and Docusaurus

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - run: npm run build
 
       - persist_to_workspace:
-          root: _site
+          root: .
           paths:
             - build/*
 
@@ -54,7 +54,7 @@ jobs:
       - run: apk add rsync
 
       # clone repo (required to access `.circleci/deploy.sh`)
-      - run: git clone https://github.com/qAIRa.github.io.git
+      - run: git clone https://github.com/qAIRa/qAIRa.github.io.git
 
       # checkout generated html
       - attach_workspace:

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-DEPLOY_DIR=~/project/gh-pages
+DEPLOY_DIR=~/project/build
 
 # trust GitHub server keys
 mkdir ~/.ssh/
@@ -13,7 +13,7 @@ ssh-keyscan github.com >> ~/.ssh/known_hosts
 
 # stage generated HTML for GitHub Pages
 git clone --quiet --branch=gh-pages $CIRCLE_REPOSITORY_URL $DEPLOY_DIR
-rsync --archive --recursive --verbose --remove-source-files $HOME/project/_site/* $DEPLOY_DIR
+rsync --archive --recursive --verbose --remove-source-files $HOME/project/build/* $DEPLOY_DIR
 
 # git client setup
 cd $DEPLOY_DIR

--- a/README.md
+++ b/README.md
@@ -55,4 +55,5 @@ npm start
 ```
 
 ## Legal notices and attributions
+
 * Uses [Circle CI implementation](https://github.com/FOSSRIT/people/tree/57100587ea79854f77087008b3bfd564a2ba79fb/.circleci) from [FOSSRIT/people](https://github.com/FOSSRIT/people) ([GPLv3](https://github.com/FOSSRIT/people/blob/57100587ea79854f77087008b3bfd564a2ba79fb/LICENSE.txt)).


### PR DESCRIPTION
This commit cleans up some cruft on the Circle CI implementation
introduced in PR #4. Some of paths were configured for Jekyll, a static
site generator. They needed to be updated for the Docusaurus build
paths. This commit attempts to get the full deployment pipeline running.

You can see my Circle CI build logs from my forked repository [here](https://app.circleci.com/pipelines/github/unicef/qAIRa.github.io/3/workflows/bb7b41ec-8159-471b-b498-1987be3bdbf2). It
shows a working `lint` and `build` job. We may still need to debug the
`deploy` job since that only runs on changes to the `master` branch.