### PR TITLE
ci: Fix deploy job paths

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - build/*
+            - ./*
 
   deploy:
     docker:

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -4,7 +4,7 @@
 #
 set -e
 
-DEPLOY_DIR=~/project/build
+DEPLOY_DIR=~/project/gh-pages
 
 # trust GitHub server keys
 mkdir ~/.ssh/


### PR DESCRIPTION
This commit makes some minor tweaks to the Circle CI deploy job to get a
working pipeline. I tested this in my fork's Circle CI pipeline and
confirmed it was working:

https://app.circleci.com/pipelines/github/unicef/qAIRa.github.io/16/workflows/aa95192b-1639-4c2f-9dbc-f0d2e0e77eef